### PR TITLE
Xf syntax fixes

### DIFF
--- a/arelle/plugin/formulaSaver.py
+++ b/arelle/plugin/formulaSaver.py
@@ -26,6 +26,7 @@ from arelle.ModelFormulaObject import (ModelValueAssertion, ModelExistenceAssert
                                        ModelEntitySpecificIdentifier, ModelEntityScheme, ModelEntityRegexpScheme,
                                        ModelEntityRegexpIdentifier, ModelMatchFilter, ModelRelativeFilter,
                                        ModelAncestorFilter, ModelParentFilter, ModelSiblingFilter, ModelNilFilter,
+                                       ModelPrecisionFilter,
                                        ModelAspectCover, ModelConceptRelation,
                                        ModelCustomFunctionSignature, ModelCustomFunctionImplementation,
                                        ModelPeriod,
@@ -308,6 +309,8 @@ class GenerateXbrlFormula:
                 self.xf = "{}sibling ${};".format(pIndent, fObj.variable)
             elif isinstance(fObj, ModelNilFilter):
                 self.xf = "{}nilled;".format(pIndent)
+            elif isinstance(fObj, ModelPrecisionFilter):
+                self.xf = "{}(: minimum-precision {}; Note: \"precision\" filter is not supported in XF (WGN-2018-10-10) :)".format(pIndent, fObj.minimum)                
             elif isinstance(fObj, ModelAspectCover):
                 aspects = []
                 for aspectElt in XmlUtil.children(fObj, XbrlConst.acf, "aspect"):

--- a/arelle/plugin/formulaSaver.py
+++ b/arelle/plugin/formulaSaver.py
@@ -42,7 +42,13 @@ def kebabCase(name):
 
 def strQuote(s):
     return '"' + s.replace('"', '""') + '"'
-        
+
+def ifrsFormulaObjIdSortKey(obj):
+    try:
+        return obj.id+'\0'+formulaObjSortKey(obj)
+    except AttributeError:
+        return None 
+
 class GenerateXbrlFormula:
     def __init__(self, modelXbrl, xfFile):
         self.modelXbrl = modelXbrl
@@ -64,7 +70,7 @@ class GenerateXbrlFormula:
         for qn, param in sorted(self.modelXbrl.qnameParameters.items(), key=lambda i:i[0]):
             self.doObject(param, None, "", set())
             
-        for rootObject in sorted(rootObjects, key=formulaObjSortKey):
+        for rootObject in sorted(rootObjects, key=ifrsFormulaObjIdSortKey):
             self.doObject(rootObject, None, "", set())
             
         if self.xmlns:

--- a/arelle/plugin/formulaSaver.py
+++ b/arelle/plugin/formulaSaver.py
@@ -18,6 +18,7 @@ from arelle.ViewUtilFormulae import rootFormulaObjects, formulaObjSortKey
 from arelle.ModelFormulaObject import (ModelValueAssertion, ModelExistenceAssertion, ModelConsistencyAssertion,
                                        ModelAssertionSet,
                                        ModelFactVariable, ModelGeneralVariable, ModelFormula, ModelParameter,
+                                       ModelPrecondition,
                                        ModelFilter, ModelConceptName, ModelConceptPeriodType, ModelConceptBalance,
                                        ModelConceptCustomAttribute, ModelConceptDataType, ModelConceptSubstitutionGroup,
                                        ModelTestFilter, ModelGeneral, ModelGeneralMeasures, ModelInstantDuration,
@@ -181,6 +182,8 @@ class GenerateXbrlFormula:
             if fObj.bindAsSequence:
                 self.xf = "{}bind-as-sequence".format(cIndent)
             self.xf = "{}select {{{}}}".format(cIndent, fObj.select)
+        elif isinstance(fObj, ModelPrecondition) and fromRel is not None:
+            self.xf = "{}precondition {{{}}};".format(pIndent, fObj.viewExpression)
         elif isinstance(fObj, ModelParameter):
             if fromRel is not None:
                 # parameter is referenced by a different QName on arc


### PR DESCRIPTION
for IFRS formula: map preconditions, sort formula by their (included in output ) id - not their xlink name, add a comment to highlight precision filters NOT mapped to the output (as not supported).